### PR TITLE
Domain – Migrate FastRoute and FastRouter to Pydantic v2 (#15)

### DIFF
--- a/tiferet_fast/domain/__init__.py
+++ b/tiferet_fast/domain/__init__.py
@@ -1,0 +1,9 @@
+"""Fast API Domain Exports"""
+
+# *** exports
+
+# ** app
+from .fast import (
+    FastRoute,
+    FastRouter,
+)

--- a/tiferet_fast/domain/fast.py
+++ b/tiferet_fast/domain/fast.py
@@ -1,0 +1,74 @@
+"""Fast API domain models."""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** infra
+from pydantic import Field
+
+# ** app
+from tiferet.domain import DomainObject
+
+# *** models
+
+# ** model: fast_route
+class FastRoute(DomainObject):
+    '''
+    A Fast route model.
+    '''
+
+    # * attribute: id
+    id: str = Field(
+        ...,
+        description='The unique identifier of the route.',
+    )
+
+    # * attribute: endpoint
+    endpoint: str = Field(
+        ...,
+        description='The unique identifier of the route endpoint.',
+    )
+
+    # * attribute: path
+    path: str = Field(
+        ...,
+        description='The URL path as string.',
+    )
+
+    # * attribute: methods
+    methods: List[str] = Field(
+        ...,
+        description='A list of HTTP methods this rule should be limited to.',
+    )
+
+    # * attribute: status_code
+    status_code: int = Field(
+        default=200,
+        description='The default HTTP status code for the route response.',
+    )
+
+# ** model: fast_router
+class FastRouter(DomainObject):
+    '''
+    A Fast router model.
+    '''
+
+    # * attribute: name
+    name: str = Field(
+        ...,
+        description='The name of the router.',
+    )
+
+    # * attribute: prefix
+    prefix: str | None = Field(
+        default=None,
+        description='The URL prefix for all routes in this router.',
+    )
+
+    # * attribute: routes
+    routes: List[FastRoute] = Field(
+        default_factory=list,
+        description='A list of routes associated with this router.',
+    )

--- a/tiferet_fast/domain/tests/test_fast.py
+++ b/tiferet_fast/domain/tests/test_fast.py
@@ -1,0 +1,111 @@
+"""Tests for Fast API domain models."""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..fast import (
+    FastRoute,
+    FastRouter,
+)
+
+# *** fixtures
+
+# ** fixture: fast_route
+@pytest.fixture
+def fast_route() -> FastRoute:
+    '''
+    A fixture that provides a sample FastRoute instance for testing.
+
+    :return: A sample FastRoute instance.
+    :rtype: FastRoute
+    '''
+
+    return FastRoute(
+        id='sample_route',
+        endpoint='sample_router.sample_route',
+        path='/sample',
+        methods=['GET', 'POST'],
+        status_code=200,
+    )
+
+# ** fixture: fast_router
+@pytest.fixture
+def fast_router(fast_route: FastRoute) -> FastRouter:
+    '''
+    A fixture that provides a sample FastRouter instance for testing.
+
+    :param fast_route: A sample FastRoute instance.
+    :type fast_route: FastRoute
+    :return: A sample FastRouter instance.
+    :rtype: FastRouter
+    '''
+
+    return FastRouter(
+        name='sample_router',
+        prefix='/sample',
+        routes=[fast_route],
+    )
+
+# *** tests
+
+# ** test: fast_route_creation
+def test_fast_route_creation(fast_route: FastRoute):
+    '''
+    Test the creation of a FastRoute instance.
+
+    :param fast_route: A sample FastRoute instance.
+    :type fast_route: FastRoute
+    '''
+
+    assert fast_route.id == 'sample_route'
+    assert fast_route.endpoint == 'sample_router.sample_route'
+    assert fast_route.path == '/sample'
+    assert fast_route.methods == ['GET', 'POST']
+    assert fast_route.status_code == 200
+
+# ** test: fast_route_default_status_code
+def test_fast_route_default_status_code():
+    '''
+    Test that FastRoute defaults status_code to 200.
+    '''
+
+    route = FastRoute(
+        id='test',
+        endpoint='router.test',
+        path='/test',
+        methods=['GET'],
+    )
+
+    assert route.status_code == 200
+
+# ** test: fast_router_creation
+def test_fast_router_creation(fast_router: FastRouter, fast_route: FastRoute):
+    '''
+    Test the creation of a FastRouter instance.
+
+    :param fast_router: A sample FastRouter instance.
+    :type fast_router: FastRouter
+    :param fast_route: A sample FastRoute instance.
+    :type fast_route: FastRoute
+    '''
+
+    assert fast_router.name == 'sample_router'
+    assert fast_router.prefix == '/sample'
+    assert len(fast_router.routes) == 1
+    assert fast_router.routes[0] == fast_route
+
+# ** test: fast_router_default_routes
+def test_fast_router_default_routes():
+    '''
+    Test that FastRouter defaults to an empty routes list.
+    '''
+
+    router = FastRouter(
+        name='empty_router',
+    )
+
+    assert router.routes == []
+    assert router.prefix is None


### PR DESCRIPTION
## Summary

Migrates the domain layer from Tiferet v1.x `ModelObject` (schematics) to Tiferet v2.0 `DomainObject` (Pydantic v2).

### Changes
- **`tiferet_fast/domain/fast.py`** — New `FastRoute` and `FastRouter` domain objects extending `DomainObject` with `pydantic.Field` annotations
- **`tiferet_fast/domain/__init__.py`** — Package exports
- **`tiferet_fast/domain/tests/test_fast.py`** — 4 tests using direct Pydantic constructors (no `ModelObject.new()`)

### Key Decisions
- `FastRouter.add_route()` mutation method removed from the domain object — will move to `FastRouterAggregate` in the Mappers story (#17)
- `prefix` field is `str | None` with `default=None` (was always optional)

Closes #15

---
[Conversation](https://app.warp.dev/conversation/5fde926c-8544-4a80-a4d1-02bb971a2815) | [Plan: Tiferet Fast v0.2 — Restructure for Tiferet v2.0-beta1](https://app.warp.dev/drive/notebook/x3qCCs0B3KCOk2wZSFCw05)

Co-Authored-By: Oz <oz-agent@warp.dev>