### PR TITLE
Contexts – Update FastApiContext and FastRequestContext for v2.0 (#20)

### DIFF
--- a/tiferet_fast/contexts/fast.py
+++ b/tiferet_fast/contexts/fast.py
@@ -4,26 +4,20 @@
 
 # ** core
 from typing import Any, Callable
-from functools import partial
 
 # ** infra
 from tiferet import TiferetError
+from tiferet.assets.exceptions import TiferetAPIError
 from tiferet.contexts import (
     AppInterfaceContext,
     FeatureContext,
     ErrorContext,
     LoggingContext
 )
-from fastapi import FastAPI
-from fastapi.routing import APIRouter
-from starlette.middleware import Middleware
-from starlette_context import context, plugins
-from starlette_context.middleware import RawContextMiddleware
+from tiferet.events import DomainEvent
 
 # ** app
 from .request import FastRequestContext
-from ..handlers import FastApiHandler
-from ..models import FastRouter
 
 # *** contexts
 
@@ -33,11 +27,11 @@ class FastApiContext(AppInterfaceContext):
     A context for managing Fast API interactions within the Tiferet framework.
     '''
 
-    # * attribute: fast_app
-    fast_app: FastAPI
+    # * attribute: get_route_handler
+    get_route_handler: Callable
 
-    # * attribute: fast_api_handler
-    fast_api_handler: FastApiHandler
+    # * attribute: get_status_code_handler
+    get_status_code_handler: Callable
 
     # * init
     def __init__(self,
@@ -45,7 +39,8 @@ class FastApiContext(AppInterfaceContext):
             features: FeatureContext,
             errors: ErrorContext,
             logging: LoggingContext,
-            fast_api_handler: FastApiHandler
+            get_route_evt: DomainEvent,
+            get_status_code_evt: DomainEvent,
         ):
         '''
         Initialize the Fast API context.
@@ -58,15 +53,18 @@ class FastApiContext(AppInterfaceContext):
         :type errors: ErrorContext
         :param logging: The logging context.
         :type logging: LoggingContext
-        :param fast_api_handler: The Fast API handler.
-        :type fast_api_handler: FastApiHandler
+        :param get_route_evt: The domain event for retrieving a route.
+        :type get_route_evt: DomainEvent
+        :param get_status_code_evt: The domain event for retrieving a status code.
+        :type get_status_code_evt: DomainEvent
         '''
 
         # Call the parent constructor.
         super().__init__(interface_id, features, errors, logging)
 
-        # Set the attributes.
-        self.fast_api_handler = fast_api_handler
+        # Set the domain event handlers.
+        self.get_route_handler = get_route_evt.execute
+        self.get_status_code_handler = get_status_code_evt.execute
 
     # * method: parse_request
     def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> FastRequestContext:
@@ -89,119 +87,53 @@ class FastApiContext(AppInterfaceContext):
         return FastRequestContext(
             headers=headers,
             data=data,
-            feature_id=feature_id
+            feature_id=feature_id,
         )
 
     # * method: handle_error
-    def handle_error(self, error: Exception) -> Any:
+    def handle_error(self, error: Exception, **kwargs) -> Any:
         '''
-        Handle the error and return the response.
+        Handle the error and return the response with status code.
 
         :param error: The error to handle.
         :type error: Exception
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
         :return: The error response.
         :rtype: Any
         '''
 
-        # Handle the error and get the response from the parent context.
-        if not isinstance(error, TiferetError):
-            return super().handle_error(error), 500
+        # Get the status code via event if it's a TiferetError.
+        if isinstance(error, TiferetError):
+            status_code = self.get_status_code_handler(error_code=error.error_code)
+        else:
+            status_code = 500
 
-        # Get the status code by the error code on the exception.
-        status_code = self.fast_api_handler.get_status_code(error.error_code)
-        return super().handle_error(error), status_code
+        # Delegate formatting to parent (which raises TiferetAPIError).
+        try:
+            return super().handle_error(error, **kwargs)
+        except TiferetAPIError as api_error:
+            api_error.status_code = status_code
+            raise
 
     # * method: handle_response
-    def handle_response(self, request: FastRequestContext) -> Any:
+    def handle_response(self, request: FastRequestContext, **kwargs) -> Any:
         '''
         Handle the response from the request context.
 
         :param request: The request context.
-        :type request: RequestContext
-        :return: The response.
+        :type request: FastRequestContext
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The response and status code.
         :rtype: Any
         '''
 
         # Handle the response from the request context.
-        response = super().handle_response(request)
+        response = super().handle_response(request, **kwargs)
 
         # Retrieve the route by the request feature id.
-        route = self.fast_api_handler.get_route(request.feature_id)
+        route = self.get_route_handler(endpoint=request.feature_id)
 
         # Return the result with the specified status code.
         return response, route.status_code if route else 200
-
-    # * method: build_router
-    def build_router(self, fast_router: FastRouter, view_func: Callable, **kwargs) -> FastAPI:
-        '''
-        Assembles a FastAPI router from the given FastRouter model.
-
-        :param fast_router: The FastRouter model.
-        :type fast_router: FastRouter
-        :param view_func: The view function to handle requests.
-        :type view_func: Callable
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The created FastAPI router.
-        :rtype: FastAPI
-        '''
-
-        # Create a FastAPI router instance.
-        router = APIRouter(
-            prefix=fast_router.prefix,
-            tags=[fast_router.name]
-        )
-
-        # Add the routes to the router.
-        for route in fast_router.routes:
-            router.add_api_route(
-                name=route.endpoint,
-                path=route.path,
-                endpoint=partial(view_func),
-                methods=route.methods,
-                status_code=route.status_code
-            )
-
-        # Return the created router.
-        return router
-
-    # * method: build_fast_app
-    def build_fast_app(self, view_func: Callable, **kwargs) -> FastAPI:
-        '''
-        Build and return a FastAPI application instance.
-
-        :param view_func: The view function to handle requests.
-        :type view_func: Callable
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A FastAPI application instance.
-        :rtype: FastAPI
-        '''
-
-        # Create middleware for context management.
-        middleware = [
-            Middleware(
-                RawContextMiddleware, 
-                plugins=(
-                    plugins.RequestIdPlugin(), 
-                    plugins.CorrelationIdPlugin(),
-                )
-            )
-        ]
-
-        # Create the FastAPI application.
-        fast_app = FastAPI(title=f"{self.interface_id} API", middleware=middleware)
-
-        # Load the FastAPI routers.
-        routers = self.fast_api_handler.get_routers()
-
-        # Create and include the routers.
-        for router in routers:
-            fast_router = self.build_router(router, view_func=view_func, **kwargs)
-            fast_app.include_router(fast_router)
-
-        # Set the fast_app attribute.
-        self.fast_app = fast_app
-
-        # Return the FastAPI application.
-        return fast_app

--- a/tiferet_fast/contexts/request.py
+++ b/tiferet_fast/contexts/request.py
@@ -6,8 +6,8 @@
 from typing import Any
 
 # ** infra
+from pydantic import BaseModel
 from tiferet.contexts.request import RequestContext
-from tiferet.models import ModelObject
 
 # *** contexts
 
@@ -45,17 +45,17 @@ class FastRequestContext(RequestContext):
         if result is None:
             self.result = ''
 
-        # Convert the response to a dictionary if it's a ModelObject.
-        elif isinstance(result, ModelObject):
-            self.result = result.to_primitive()
+        # Convert the response to a dictionary if it's a BaseModel.
+        elif isinstance(result, BaseModel):
+            self.result = result.model_dump()
 
-        # If the response is a list containing model objects, convert each to a dictionary.
-        elif isinstance(result, list) and all(isinstance(item, ModelObject) for item in result):
-            self.result = [item.to_primitive() for item in result]
+        # If the response is a list containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, list) and all(isinstance(item, BaseModel) for item in result):
+            self.result = [item.model_dump() for item in result]
 
-        # If the response is a dict containing model objects, convert each to a dictionary.
-        elif isinstance(result, dict) and all(isinstance(value, ModelObject) for value in result.values()):
-            self.result = {key: value.to_primitive() for key, value in result.items()}
+        # If the response is a dict containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, dict) and all(isinstance(value, BaseModel) for value in result.values()):
+            self.result = {key: value.model_dump() for key, value in result.items()}
 
         # Otherwise, set the result directly.
         else:

--- a/tiferet_fast/contexts/tests/test_fast.py
+++ b/tiferet_fast/contexts/tests/test_fast.py
@@ -5,54 +5,39 @@
 # ** infra
 import pytest
 from unittest import mock
-from fastapi import FastAPI
-from fastapi.routing import APIRouter
-from tiferet import (
-    ModelObject,
-    TiferetError
-)
-
-# ** app
-from ...contexts.fast import FastApiContext
-from ...contexts.request import FastRequestContext
-from ...models.fast import (
-    FastRouter,
-    FastRoute
-)
-from ...handlers.fast import FastApiHandler
+from tiferet import TiferetError
+from tiferet.assets.exceptions import TiferetAPIError
+from tiferet.events import DomainEvent
 from tiferet.contexts.error import ErrorContext
 from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
 
+# ** app
+from ...contexts.fast import FastApiContext
+from ...contexts.request import FastRequestContext
+from ...domain import FastRoute, FastRouter
+
 # *** fixtures
 
-# ** fixture: fast_router
+# ** fixture: sample_route
 @pytest.fixture
-def fast_router() -> FastRouter:
+def sample_route() -> FastRoute:
     '''
-    Fixture to provide a sample FastRouter instance for testing.
+    Fixture to provide a sample FastRoute instance for testing.
     '''
 
-    # Create a FastRouter instance.
-    return ModelObject.new(
-        FastRouter,
-        name='calc',
-        prefix='/calc',
-        routes=[
-            ModelObject.new(
-                FastRoute,
-                id='add',
-                endpoint='calc.add',
-                path='/add',
-                methods=['GET', 'POST'],
-                status_code=200
-            )
-        ]
+    # Create a FastRoute instance.
+    return FastRoute(
+        id='add',
+        endpoint='calc.add',
+        path='/add',
+        methods=['GET', 'POST'],
+        status_code=200,
     )
 
 # ** fixture: fast_api_context
 @pytest.fixture
-def fast_api_context(fast_router: FastRouter) -> FastApiContext:
+def fast_api_context(sample_route: FastRoute) -> FastApiContext:
     '''
     Fixture to provide a FastApiContext instance for testing.
     '''
@@ -62,23 +47,22 @@ def fast_api_context(fast_router: FastRouter) -> FastApiContext:
 
     # Create a mock error context.
     mock_errors = mock.Mock(spec=ErrorContext)
-    mock_errors.handle_error.return_value = {'message': 'An error occurred.'}
+    mock_errors.handle_error.return_value = {
+        'error_code': 'APP_ERROR',
+        'name': 'Application Error',
+        'message': 'An error occurred.',
+    }
 
     # Create a mock logging context.
     mock_logging = mock.Mock(spec=LoggingContext)
 
-    # Create a mock FastApiHandler.
-    mock_handler = mock.Mock(spec=FastApiHandler)
-    mock_handler.get_routers.return_value = [fast_router]
-    mock_handler.get_status_code.return_value = 400
-    mock_handler.get_route.return_value = ModelObject.new(
-        FastRoute,
-        id='add',
-        endpoint='calc.add',
-        path='/add',
-        methods=['GET', 'POST'],
-        status_code=200
-    )
+    # Create a mock get_route_evt.
+    mock_get_route_evt = mock.Mock(spec=DomainEvent)
+    mock_get_route_evt.execute = mock.Mock(return_value=sample_route)
+
+    # Create a mock get_status_code_evt.
+    mock_get_status_code_evt = mock.Mock(spec=DomainEvent)
+    mock_get_status_code_evt.execute = mock.Mock(return_value=400)
 
     # Create and return the FastApiContext instance.
     return FastApiContext(
@@ -86,7 +70,8 @@ def fast_api_context(fast_router: FastRouter) -> FastApiContext:
         features=mock_features,
         errors=mock_errors,
         logging=mock_logging,
-        fast_api_handler=mock_handler
+        get_route_evt=mock_get_route_evt,
+        get_status_code_evt=mock_get_status_code_evt,
     )
 
 # *** tests
@@ -120,7 +105,7 @@ def test_fast_api_context_parse_request(fast_api_context: FastApiContext):
 # ** test: fast_api_context_handle_error
 def test_fast_api_context_handle_error(fast_api_context: FastApiContext):
     '''
-    Test the handle_error method of FastApiContext.
+    Test the handle_error method of FastApiContext with a generic exception.
 
     :param fast_api_context: A FastApiContext instance.
     :type fast_api_context: FastApiContext
@@ -129,12 +114,12 @@ def test_fast_api_context_handle_error(fast_api_context: FastApiContext):
     # Create a sample exception.
     sample_exception = Exception('Sample error')
 
-    # Call the handle_error method.
-    response, status_code = fast_api_context.handle_error(sample_exception)
+    # Call the handle_error method and expect TiferetAPIError.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        fast_api_context.handle_error(sample_exception)
 
-    # Assert that the response is a tuple of (response, status_code).
-    assert isinstance(response, dict)
-    assert status_code == 500
+    # Assert the status code is 500 for non-TiferetError.
+    assert exc_info.value.status_code == 500
 
 # ** test: fast_api_context_handle_tiferet_error
 def test_fast_api_context_handle_tiferet_error(fast_api_context: FastApiContext):
@@ -151,18 +136,17 @@ def test_fast_api_context_handle_tiferet_error(fast_api_context: FastApiContext)
     # Mock the error handler to return a specific response.
     fast_api_context.errors.handle_error.return_value = {
         'error_code': 'INVALID_INPUT',
-        'text': 'Invalid input provided.'
+        'name': 'Invalid Input',
+        'message': 'Invalid input provided.',
     }
 
-    # Call the handle_error method.
-    response, status_code = fast_api_context.handle_error(sample_tiferet_error)
+    # Call the handle_error method and expect TiferetAPIError.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        fast_api_context.handle_error(sample_tiferet_error)
 
-    # Assert that the response is a tuple of (response, status_code).
-    assert response == {
-        'error_code': 'INVALID_INPUT',
-        'text': 'Invalid input provided.'
-    }
-    assert status_code == 400
+    # Assert the status code is 400 (from mock get_status_code_evt).
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.error_code == 'INVALID_INPUT'
 
 # ** test: fast_api_context_handle_response
 def test_fast_api_context_handle_response(fast_api_context: FastApiContext):
@@ -189,51 +173,3 @@ def test_fast_api_context_handle_response(fast_api_context: FastApiContext):
     # Assert that the response is as expected.
     assert response == {'result_key': 'result_value'}
     assert status_code == 200
-
-# ** test: fast_api_context_build_router
-def test_fast_api_context_build_router(fast_api_context: FastApiContext, fast_router: FastRouter):
-    '''
-    Test the build_router method of FastApiContext.
-
-    :param fast_api_context: A FastApiContext instance.
-    :type fast_api_context: FastApiContext
-    :param fast_router: A FastRouter instance.
-    :type fast_router: FastRouter
-    '''
-
-    # Create a sample view function.
-    def sample_view_func():
-        return 'Sample Response'
-
-    # Build a sample router.
-    router = fast_api_context.build_router(
-        fast_router=fast_router,
-        view_func=sample_view_func
-    )
-
-    # Assert that the returned object is a FastAPI instance.
-    assert isinstance(router, APIRouter)
-    assert router.tags == ['calc']
-    assert router.prefix == '/calc'
-
-# ** test: fast_api_context_build_fast_app
-def test_fast_api_context_build_fast_app(fast_api_context: FastApiContext):
-    '''
-    Test the build_fast_app method of FastApiContext.
-
-    :param fast_api_context: A FastApiContext instance.
-    :type fast_api_context: FastApiContext
-    '''
-
-    # Create a sample view function.
-    def sample_view_func():
-        return 'Sample Response'
-
-    # Build a sample FastAPI app.
-    fast_app = fast_api_context.build_fast_app(
-        view_func=sample_view_func
-    )
-
-    # Assert that the returned object is a FastAPI instance.
-    assert isinstance(fast_api_context.fast_app, FastAPI)
-    assert fast_app.title == 'test_fast API'

--- a/tiferet_fast/contexts/tests/test_request.py
+++ b/tiferet_fast/contexts/tests/test_request.py
@@ -4,10 +4,8 @@
 
 # ** infra
 import pytest
-from tiferet import (
-    ModelObject,
-    StringType
-)
+from pydantic import Field
+from tiferet.domain import DomainObject
 
 # ** app
 from ...contexts.request import FastRequestContext
@@ -92,55 +90,49 @@ def test_fast_request_context_handle_response_data(fast_request_context):
     # Check that the response is as expected.
     assert response == {'key': 'value'}
 
-# ** test: fast_request_context_handle_response_model_object
-def test_fast_request_context_handle_response_model_object(fast_request_context):
+# ** test: fast_request_context_handle_response_domain_object
+def test_fast_request_context_handle_response_domain_object(fast_request_context):
     '''
-    Test handling a response that is a ModelObject in the FastRequestContext.
+    Test handling a response that is a DomainObject in the FastRequestContext.
 
     :param fast_request_context: The FastRequestContext instance.
     :type fast_request_context: FastRequestContext
     '''
 
-    # Create a ModelObject to simulate a response.
-    class Data(ModelObject):
-        key = StringType(
-            default='default_value',
-            required=True
-        )
+    # Create a DomainObject to simulate a response.
+    class Data(DomainObject):
+        key: str = Field(default='default_value', description='A key field.')
 
-    # Set the request context result to a ModelObject.
-    fast_request_context.set_result(ModelObject.new(Data, key='value'))
+    # Set the request context result to a DomainObject.
+    fast_request_context.set_result(Data(key='value'))
 
-    # Handle the response with a ModelObject.
+    # Handle the response with a DomainObject.
     response = fast_request_context.handle_response()
 
     # Check that the response is a dictionary with expected data.
     assert isinstance(response, dict)
     assert response.get('key') == 'value'
 
-# ** test: fast_request_context_handle_response_model_list
-def test_fast_request_context_handle_response_model_list(fast_request_context):
+# ** test: fast_request_context_handle_response_domain_list
+def test_fast_request_context_handle_response_domain_list(fast_request_context):
     '''
-    Test handling a response that is a list of ModelObjects in the FastRequestContext.
+    Test handling a response that is a list of DomainObjects in the FastRequestContext.
 
     :param fast_request_context: The FastRequestContext instance.
     :type fast_request_context: FastRequestContext
     '''
 
-    # Create a ModelObject to simulate a response.
-    class Item(ModelObject):
-        name = StringType(
-            default='default_name',
-            required=True
-        )
+    # Create a DomainObject to simulate a response.
+    class Item(DomainObject):
+        name: str = Field(default='default_name', description='A name field.')
 
-    # Set the request context result to a list of ModelObjects.
+    # Set the request context result to a list of DomainObjects.
     fast_request_context.set_result([
-        ModelObject.new(Item, name='item1'),
-        ModelObject.new(Item, name='item2')
+        Item(name='item1'),
+        Item(name='item2'),
     ])
 
-    # Handle the response with a list of ModelObjects.
+    # Handle the response with a list of DomainObjects.
     response = fast_request_context.handle_response()
 
     # Check that the response is a list and contains expected data.
@@ -149,29 +141,26 @@ def test_fast_request_context_handle_response_model_list(fast_request_context):
     assert response[0].get('name') == 'item1'
     assert response[1].get('name') == 'item2'
 
-# ** test: fast_request_context_handle_response_model_dict
-def test_fast_request_context_handle_response_model_dict(fast_request_context):
+# ** test: fast_request_context_handle_response_domain_dict
+def test_fast_request_context_handle_response_domain_dict(fast_request_context):
     '''
-    Test handling a response that is a dict of ModelObjects in the FastRequestContext.
+    Test handling a response that is a dict of DomainObjects in the FastRequestContext.
 
     :param fast_request_context: The FastRequestContext instance.
     :type fast_request_context: FastRequestContext
     '''
 
-    # Create a ModelObject to simulate a response.
-    class Item(ModelObject):
-        name = StringType(
-            default='default_name',
-            required=True
-        )
+    # Create a DomainObject to simulate a response.
+    class Item(DomainObject):
+        name: str = Field(default='default_name', description='A name field.')
 
-    # Set the request context result to a dict of ModelObjects.
+    # Set the request context result to a dict of DomainObjects.
     fast_request_context.set_result({
-        'item1': ModelObject.new(Item, name='item1'),
-        'item2': ModelObject.new(Item, name='item2')
+        'item1': Item(name='item1'),
+        'item2': Item(name='item2'),
     })
 
-    # Handle the response with a dict of ModelObjects.
+    # Handle the response with a dict of DomainObjects.
     response = fast_request_context.handle_response()
 
     # Check that the response is a dict and contains expected data.


### PR DESCRIPTION
## Summary

Update the context layer to align with Tiferet v2.0 patterns. Migrates `FastRequestContext` from `ModelObject`/`to_primitive()` to `BaseModel`/`model_dump()`. Slims `FastApiContext` to focus on request/response lifecycle — build methods move to `FastApiBuilder` (issue #21).

## Changes

### FastRequestContext (`contexts/request.py`)
- Replace `ModelObject` import with `pydantic.BaseModel`.
- Replace `isinstance(result, ModelObject)` checks with `isinstance(result, BaseModel)`.
- Replace `to_primitive()` calls with `model_dump()`.

### FastApiContext (`contexts/fast.py`)
- Constructor now accepts `get_route_evt: DomainEvent` and `get_status_code_evt: DomainEvent` instead of `FastApiHandler`.
- Removed `build_router()` and `build_fast_app()` (move to `FastApiBuilder`).
- `handle_error()` resolves HTTP status codes via `GetStatusCode` event, catches `TiferetAPIError` from parent, sets `status_code`, re-raises.
- `handle_response()` resolves route status codes via `GetRoute` event.

### Tests
- **`test_request.py`**: `DomainObject`/`Field` instead of `ModelObject`/`StringType`.
- **`test_fast.py`**: Mock domain events instead of `FastApiHandler`. Removed `test_build_router` and `test_build_fast_app`. Updated error tests to expect `TiferetAPIError`.

## Testing

All 10 tests pass (4 context + 6 request).

Resolves #20

Co-Authored-By: Oz <oz-agent@warp.dev>