### PR TITLE
Builders – Add FastApiBuilder (#21)

### DIFF
--- a/tiferet_fast/__init__.py
+++ b/tiferet_fast/__init__.py
@@ -3,11 +3,11 @@
 # *** exports
 
 # ** app
-# Export the main application context and related modules.
+# Export the main application builder and related modules.
 # Use a try-except block to avoid import errors on build systems.
 try:
-    from .contexts import FastApiContext
-except:
+    from .builders import FastApiBuilder, FastApiBuilder as FastAPI
+except Exception:
     pass
 
 # *** version

--- a/tiferet_fast/builders/__init__.py
+++ b/tiferet_fast/builders/__init__.py
@@ -1,0 +1,9 @@
+"""Fast API Builder Exports."""
+
+# *** exports
+
+# ** app
+from .fast import (
+    FastApiBuilder,
+    FastApiBuilder as FastAPI,
+)

--- a/tiferet_fast/builders/fast.py
+++ b/tiferet_fast/builders/fast.py
@@ -1,0 +1,136 @@
+"""Fast API Builder."""
+
+# *** imports
+
+# ** core
+from typing import Any, Callable, List
+from functools import partial
+
+# ** infra
+from fastapi import FastAPI as FastAPIApp
+from fastapi.routing import APIRouter
+from starlette.middleware import Middleware
+from starlette_context import plugins
+from starlette_context.middleware import RawContextMiddleware
+from tiferet.builders import AppBuilder
+
+# ** app
+from ..domain import FastRouter
+from ..contexts import FastApiContext
+
+# *** builders
+
+# ** builder: fast_api_builder
+class FastApiBuilder(AppBuilder):
+    '''
+    Specialized application builder for FastAPI applications.
+    '''
+
+    # * method: get_routers
+    def get_routers(self) -> List[FastRouter]:
+        '''
+        Resolve and execute the get_routers event from the service provider.
+
+        :return: A list of FastRouter domain objects.
+        :rtype: List[FastRouter]
+        '''
+
+        # Resolve the get_routers event and execute it.
+        get_routers_evt = self.service_provider.get_service('get_routers_evt')
+        return get_routers_evt.execute()
+
+    # * method: build_router
+    def build_router(self, fast_router: FastRouter, view_func: Callable, **kwargs) -> APIRouter:
+        '''
+        Build an APIRouter from a FastRouter domain object.
+
+        :param fast_router: The FastRouter domain object.
+        :type fast_router: FastRouter
+        :param view_func: The view function to handle requests.
+        :type view_func: Callable
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A configured APIRouter instance.
+        :rtype: APIRouter
+        '''
+
+        # Create an APIRouter instance.
+        router = APIRouter(
+            prefix=fast_router.prefix,
+            tags=[fast_router.name],
+        )
+
+        # Add routes from the FastRouter domain object.
+        for route in fast_router.routes:
+            router.add_api_route(
+                name=route.endpoint,
+                path=route.path,
+                endpoint=partial(view_func),
+                methods=route.methods,
+                status_code=route.status_code,
+            )
+
+        # Return the configured router.
+        return router
+
+    # * method: build_fast_app
+    def build_fast_app(self, interface_id: str, view_func: Callable, **kwargs) -> FastAPIApp:
+        '''
+        Build a complete FastAPI application with middleware and routers.
+
+        :param interface_id: The interface ID to load.
+        :type interface_id: str
+        :param view_func: The view function to handle requests.
+        :type view_func: Callable
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A configured FastAPI application instance.
+        :rtype: FastAPIApp
+        '''
+
+        # Load the interface context.
+        interface_context = self.load_interface(interface_id)
+
+        # Create middleware.
+        middleware = [
+            Middleware(
+                RawContextMiddleware,
+                plugins=(
+                    plugins.RequestIdPlugin(),
+                    plugins.CorrelationIdPlugin(),
+                ),
+            )
+        ]
+
+        # Create the FastAPI app.
+        fast_app = FastAPIApp(
+            title=f'{interface_id} API',
+            middleware=middleware,
+        )
+
+        # Load and include routers.
+        routers = self.get_routers()
+        for fast_router in routers:
+            api_router = self.build_router(fast_router, view_func=view_func, **kwargs)
+            fast_app.include_router(api_router)
+
+        # Return the assembled FastAPI application.
+        return fast_app
+
+    # * method: run
+    def run(self, interface_id: str, view_func: Callable, **kwargs) -> FastAPIApp:
+        '''
+        Build and return a ready-to-serve FastAPI application.
+
+        :param interface_id: The interface ID to load.
+        :type interface_id: str
+        :param view_func: The view function to handle requests.
+        :type view_func: Callable
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A configured FastAPI application instance.
+        :rtype: FastAPIApp
+        '''
+
+        # Build and return the FastAPI application.
+        return self.build_fast_app(interface_id, view_func, **kwargs)


### PR DESCRIPTION
## Summary

Add `FastApiBuilder(AppBuilder)` as the primary entry point for tiferet-fast applications, following the same builder pattern as `CliBuilder(AppBuilder)` in `tiferet.builders.cli`. Replaces the v0.1 pattern where `FastApiContext` handled both lifecycle and app-building concerns.

## Changes

- **`tiferet_fast/builders/fast.py`** — `FastApiBuilder(AppBuilder)` with:
  - `get_routers()` — Resolves `get_routers_evt` from the service provider and executes it.
  - `build_router()` — Builds an `APIRouter` from a `FastRouter` domain object with routes.
  - `build_fast_app()` — Assembles a complete `FastAPI` instance with middleware and routers.
  - `run()` — Convenience method that delegates to `build_fast_app()`.
- **`tiferet_fast/builders/__init__.py`** — Exports `FastApiBuilder` and `FastAPI` alias.
- **`tiferet_fast/__init__.py`** — Updated top-level exports to `FastApiBuilder`/`FastAPI` from builders.

## Verification

- `from tiferet_fast import FastAPI` imports successfully.
- `from tiferet_fast.builders import FastApiBuilder, FastAPI` imports successfully.
- Both aliases resolve to the same class.

Resolves #21

Co-Authored-By: Oz <oz-agent@warp.dev>