### PR TITLE
Fix FastRequestContext.set_result() missing data_key parameter (#31)

### DIFF
--- a/tiferet_fast/__init__.py
+++ b/tiferet_fast/__init__.py
@@ -12,4 +12,4 @@ except Exception:
 
 # *** version
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tiferet_fast/contexts/request.py
+++ b/tiferet_fast/contexts/request.py
@@ -33,13 +33,22 @@ class FastRequestContext(RequestContext):
         return super().handle_response()
 
     # * method: set_result
-    def set_result(self, result: Any):
+    def set_result(self, result: Any, data_key: str = None):
         '''
         Set the result of the request context.
 
         :param result: The result to set.
         :type result: Any
+        :param data_key: The key in the request data to set the result to.
+            If provided, the raw result is stored for downstream commands.
+            If None, the result is serialized for the final response.
+        :type data_key: str
         '''
+
+        # If a data key is provided, delegate to the parent to store the raw result.
+        if data_key:
+            super().set_result(result, data_key=data_key)
+            return
 
         # If the response is None, return an empty response.
         if result is None:

--- a/tiferet_fast/contexts/tests/test_request.py
+++ b/tiferet_fast/contexts/tests/test_request.py
@@ -168,3 +168,73 @@ def test_fast_request_context_handle_response_domain_dict(fast_request_context):
     assert len(response) == 2
     assert response['item1'].get('name') == 'item1'
     assert response['item2'].get('name') == 'item2'
+
+# ** test: fast_request_context_set_result_data_key_domain_object
+def test_fast_request_context_set_result_data_key_domain_object(fast_request_context):
+    '''
+    Test that set_result with data_key stores the raw DomainObject without serialization.
+
+    :param fast_request_context: The FastRequestContext instance.
+    :type fast_request_context: FastRequestContext
+    '''
+
+    # Create a DomainObject to simulate an intermediate pipeline result.
+    class Device(DomainObject):
+        is_active: bool = Field(default=True, description='Whether the device is active.')
+
+    # Create a device instance.
+    device = Device(is_active=True)
+
+    # Set the result with a data_key to store the raw object.
+    fast_request_context.set_result(device, data_key='device')
+
+    # Assert the raw DomainObject is stored in data, not serialized.
+    assert fast_request_context.data['device'] is device
+    assert isinstance(fast_request_context.data['device'], Device)
+
+    # Assert the final result is not set.
+    assert fast_request_context.result is None
+
+# ** test: fast_request_context_set_result_data_key_primitive
+def test_fast_request_context_set_result_data_key_primitive(fast_request_context):
+    '''
+    Test that set_result with data_key stores a primitive value in request data.
+
+    :param fast_request_context: The FastRequestContext instance.
+    :type fast_request_context: FastRequestContext
+    '''
+
+    # Set the result with a data_key to store a primitive.
+    fast_request_context.set_result('raw_string', data_key='raw')
+
+    # Assert the primitive is stored in data.
+    assert fast_request_context.data['raw'] == 'raw_string'
+
+    # Assert the final result is not set.
+    assert fast_request_context.result is None
+
+# ** test: fast_request_context_set_result_data_key_list
+def test_fast_request_context_set_result_data_key_list(fast_request_context):
+    '''
+    Test that set_result with data_key stores a list of DomainObjects without serialization.
+
+    :param fast_request_context: The FastRequestContext instance.
+    :type fast_request_context: FastRequestContext
+    '''
+
+    # Create a DomainObject to simulate list items.
+    class Item(DomainObject):
+        name: str = Field(default='default_name', description='A name field.')
+
+    # Create a list of items.
+    items = [Item(name='item1'), Item(name='item2')]
+
+    # Set the result with a data_key to store the raw list.
+    fast_request_context.set_result(items, data_key='items')
+
+    # Assert the raw list of DomainObjects is stored in data.
+    assert fast_request_context.data['items'] is items
+    assert all(isinstance(item, Item) for item in fast_request_context.data['items'])
+
+    # Assert the final result is not set.
+    assert fast_request_context.result is None


### PR DESCRIPTION
## Summary

Fixes #31 — `FastRequestContext.set_result()` was missing the `data_key` parameter from the parent `RequestContext`, causing intermediate pipeline results to be serialized via `model_dump()` and stored in `self.result` instead of preserved as raw domain objects in `self.data[data_key]`.

## Changes

- **`tiferet_fast/contexts/request.py`**: Added `data_key: str = None` parameter to `set_result()`. When `data_key` is provided, delegates to the parent to store the raw result. Serialization is restricted to the final-response path.
- **`tiferet_fast/contexts/tests/test_request.py`**: Added 3 new tests covering `data_key` storage for domain objects, primitives, and lists.
- **`tiferet_fast/__init__.py`**: Version bump to `0.2.1`.

## Test Results

All 36 tests pass.

---

[Warp Conversation](https://app.warp.dev/conversation/708f8543-64b2-4e2c-9c18-0a85e2da8183)

Co-Authored-By: Oz <oz-agent@warp.dev>