### PR TITLE
Contexts – Adopt OpenApiContext and OpenApiRequestContext (#34)

### DIFF
--- a/tiferet_fast/contexts/__init__.py
+++ b/tiferet_fast/contexts/__init__.py
@@ -1,4 +1,4 @@
-"""Fast API Context Exports."""
+'''FastAPI contexts.'''
 
 # *** exports
 

--- a/tiferet_fast/contexts/fast.py
+++ b/tiferet_fast/contexts/fast.py
@@ -1,139 +1,15 @@
-"""Fast API Context for Tiferet framework."""
+'''FastAPI context.'''
 
 # *** imports
 
-# ** core
-from typing import Any, Callable
-
 # ** infra
-from tiferet import TiferetError
-from tiferet.assets.exceptions import TiferetAPIError
-from tiferet.contexts import (
-    AppInterfaceContext,
-    FeatureContext,
-    ErrorContext,
-    LoggingContext
-)
-from tiferet.events import DomainEvent
-
-# ** app
-from .request import FastRequestContext
+from tiferet_openapi import OpenApiContext
 
 # *** contexts
 
 # ** context: fast_api_context
-class FastApiContext(AppInterfaceContext):
+class FastApiContext(OpenApiContext):
     '''
-    A context for managing Fast API interactions within the Tiferet framework.
+    A FastAPI-specific API context extending the shared OpenAPI context.
     '''
-
-    # * attribute: get_route_handler
-    get_route_handler: Callable
-
-    # * attribute: get_status_code_handler
-    get_status_code_handler: Callable
-
-    # * init
-    def __init__(self,
-            interface_id: str,
-            features: FeatureContext,
-            errors: ErrorContext,
-            logging: LoggingContext,
-            get_route_evt: DomainEvent,
-            get_status_code_evt: DomainEvent,
-        ):
-        '''
-        Initialize the Fast API context.
-
-        :param interface_id: The interface ID.
-        :type interface_id: str
-        :param features: The feature context.
-        :type features: FeatureContext
-        :param errors: The error context.
-        :type errors: ErrorContext
-        :param logging: The logging context.
-        :type logging: LoggingContext
-        :param get_route_evt: The domain event for retrieving a route.
-        :type get_route_evt: DomainEvent
-        :param get_status_code_evt: The domain event for retrieving a status code.
-        :type get_status_code_evt: DomainEvent
-        '''
-
-        # Call the parent constructor.
-        super().__init__(interface_id, features, errors, logging)
-
-        # Set the domain event handlers.
-        self.get_route_handler = get_route_evt.execute
-        self.get_status_code_handler = get_status_code_evt.execute
-
-    # * method: parse_request
-    def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> FastRequestContext:
-        '''
-        Parse the incoming request and return a FastRequestContext instance.
-
-        :param headers: The request headers.
-        :type headers: dict
-        :param data: The request data.
-        :type data: dict
-        :param feature_id: The feature ID.
-        :type feature_id: str
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A FastRequestContext instance.
-        :rtype: FastRequestContext
-        '''
-
-        # Return a FastRequestContext instance.
-        return FastRequestContext(
-            headers=headers,
-            data=data,
-            feature_id=feature_id,
-        )
-
-    # * method: handle_error
-    def handle_error(self, error: Exception, **kwargs) -> Any:
-        '''
-        Handle the error and return the response with status code.
-
-        :param error: The error to handle.
-        :type error: Exception
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The error response.
-        :rtype: Any
-        '''
-
-        # Get the status code via event if it's a TiferetError.
-        if isinstance(error, TiferetError):
-            status_code = self.get_status_code_handler(error_code=error.error_code)
-        else:
-            status_code = 500
-
-        # Delegate formatting to parent (which raises TiferetAPIError).
-        try:
-            return super().handle_error(error, **kwargs)
-        except TiferetAPIError as api_error:
-            api_error.status_code = status_code
-            raise
-
-    # * method: handle_response
-    def handle_response(self, request: FastRequestContext, **kwargs) -> Any:
-        '''
-        Handle the response from the request context.
-
-        :param request: The request context.
-        :type request: FastRequestContext
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The response and status code.
-        :rtype: Any
-        '''
-
-        # Handle the response from the request context.
-        response = super().handle_response(request, **kwargs)
-
-        # Retrieve the route by the request feature id.
-        route = self.get_route_handler(endpoint=request.feature_id)
-
-        # Return the result with the specified status code.
-        return response, route.status_code if route else 200
+    pass

--- a/tiferet_fast/contexts/request.py
+++ b/tiferet_fast/contexts/request.py
@@ -1,71 +1,11 @@
-"""Fast API Request Context"""
+'''FastAPI request context.'''
 
 # *** imports
 
-# ** core
-from typing import Any
-
 # ** infra
-from pydantic import BaseModel
-from tiferet.contexts.request import RequestContext
+from tiferet_openapi import OpenApiRequestContext
 
 # *** contexts
 
 # ** context: fast_request_context
-class FastRequestContext(RequestContext):
-    '''
-    A context for handling Fast API request data and responses.
-    '''
-
-    # * method: handle_response
-    def handle_response(self) -> Any:
-        '''
-        Handle the response for the Fast API request context.
-
-        :return: The response.
-        :rtype: Any
-        '''
-
-        # Set the result using the set_result method to ensure proper formatting.
-        self.set_result(self.result)
-
-        # Handle the response using the parent method.
-        return super().handle_response()
-
-    # * method: set_result
-    def set_result(self, result: Any, data_key: str = None):
-        '''
-        Set the result of the request context.
-
-        :param result: The result to set.
-        :type result: Any
-        :param data_key: The key in the request data to set the result to.
-            If provided, the raw result is stored for downstream commands.
-            If None, the result is serialized for the final response.
-        :type data_key: str
-        '''
-
-        # If a data key is provided, delegate to the parent to store the raw result.
-        if data_key:
-            super().set_result(result, data_key=data_key)
-            return
-
-        # If the response is None, return an empty response.
-        if result is None:
-            self.result = ''
-
-        # Convert the response to a dictionary if it's a BaseModel.
-        elif isinstance(result, BaseModel):
-            self.result = result.model_dump()
-
-        # If the response is a list containing BaseModel instances, convert each to a dictionary.
-        elif isinstance(result, list) and all(isinstance(item, BaseModel) for item in result):
-            self.result = [item.model_dump() for item in result]
-
-        # If the response is a dict containing BaseModel instances, convert each to a dictionary.
-        elif isinstance(result, dict) and all(isinstance(value, BaseModel) for value in result.values()):
-            self.result = {key: value.model_dump() for key, value in result.items()}
-
-        # Otherwise, set the result directly.
-        else:
-            self.result = result
+FastRequestContext = OpenApiRequestContext

--- a/tiferet_fast/contexts/tests/test_fast.py
+++ b/tiferet_fast/contexts/tests/test_fast.py
@@ -11,23 +11,23 @@ from tiferet.events import DomainEvent
 from tiferet.contexts.error import ErrorContext
 from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
+from tiferet_openapi.domain import ApiRoute
 
 # ** app
 from ...contexts.fast import FastApiContext
 from ...contexts.request import FastRequestContext
-from ...domain import FastRoute, FastRouter
 
 # *** fixtures
 
 # ** fixture: sample_route
 @pytest.fixture
-def sample_route() -> FastRoute:
+def sample_route() -> ApiRoute:
     '''
-    Fixture to provide a sample FastRoute instance for testing.
+    Fixture to provide a sample ApiRoute instance for testing.
     '''
 
-    # Create a FastRoute instance.
-    return FastRoute(
+    # Create an ApiRoute instance.
+    return ApiRoute(
         id='add',
         endpoint='calc.add',
         path='/add',
@@ -37,7 +37,7 @@ def sample_route() -> FastRoute:
 
 # ** fixture: fast_api_context
 @pytest.fixture
-def fast_api_context(sample_route: FastRoute) -> FastApiContext:
+def fast_api_context(sample_route: ApiRoute) -> FastApiContext:
     '''
     Fixture to provide a FastApiContext instance for testing.
     '''
@@ -64,6 +64,10 @@ def fast_api_context(sample_route: FastRoute) -> FastApiContext:
     mock_get_status_code_evt = mock.Mock(spec=DomainEvent)
     mock_get_status_code_evt.execute = mock.Mock(return_value=400)
 
+    # Create a mock get_routers_evt.
+    mock_get_routers_evt = mock.Mock(spec=DomainEvent)
+    mock_get_routers_evt.execute = mock.Mock(return_value=[])
+
     # Create and return the FastApiContext instance.
     return FastApiContext(
         interface_id='test_fast',
@@ -72,6 +76,7 @@ def fast_api_context(sample_route: FastRoute) -> FastApiContext:
         logging=mock_logging,
         get_route_evt=mock_get_route_evt,
         get_status_code_evt=mock_get_status_code_evt,
+        get_routers_evt=mock_get_routers_evt,
     )
 
 # *** tests


### PR DESCRIPTION
## Summary

Refactors `FastApiContext` and `FastRequestContext` to extend `tiferet-openapi` base contexts, replacing the deleted FastAPI-specific domain types from #33.

Closes #34

## Changes

- **`contexts/fast.py`** — Replaced full implementation with a thin `OpenApiContext` subclass (no overrides).
- **`contexts/request.py`** — Replaced `FastRequestContext` class with an alias for `OpenApiRequestContext`.
- **`contexts/__init__.py`** — Updated module docstring; exports unchanged.
- **`contexts/tests/test_fast.py`** — Replaced `FastRoute` with `ApiRoute` from `tiferet_openapi`; added `get_routers_evt` mock to match `OpenApiContext` constructor.
- **`contexts/tests/test_request.py`** — No changes needed (alias is transparent).

## Verification

- All 13 context tests pass.

---

[Warp conversation](https://app.warp.dev/conversation/006d1432-2771-4383-a372-b241244746c8)

Co-Authored-By: Oz <oz-agent@warp.dev>