### PR TITLE
Packaging – Version Bump, Exports, README, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Tiferet Fast (v0.2.0)
+# AGENTS.md — Tiferet Fast (v0.3.0)
 
 ## Project Overview
 
-**Tiferet Fast** is a FastAPI extension for the Tiferet Python framework, enabling high-performance asynchronous APIs grounded in Domain-Driven Design (DDD). It extends Tiferet's layered architecture with FastAPI-specific builders, contexts, domain events, and YAML-backed route configuration.
+**Tiferet Fast** is a thin FastAPI adapter for the Tiferet Python framework. Starting with v0.3, all domain objects, service interfaces, domain events, mappers, and repositories live in [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi). This package provides only FastAPI-specific builder assembly and context error handling.
 
 - **Repository:** https://github.com/greatstrength/tiferet-fast
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.2.0`
-- **Dependency:** `tiferet>=2.0.0b1`
+- **Version:** `0.3.0`
+- **Dependencies:** `tiferet>=2.0.0b1`, `tiferet-openapi>=0.1.2`, `fastapi>=0.118.0`, `starlette-context>=0.4.0`
 
 ## Architecture
 
@@ -16,46 +16,40 @@
 
 ```
 tiferet_fast/
-├── builders/       # FastApiBuilder (primary entry point, aliased as FastAPI)
-├── contexts/       # FastApiContext, FastRequestContext
-├── domain/         # FastRoute, FastRouter (Pydantic v2 DomainObject)
-├── events/         # GetRouters, GetRoute, GetStatusCode (DomainEvent subclasses)
-├── interfaces/     # FastApiService (Service ABC)
-├── mappers/        # Aggregates + YAML TransferObjects for routes/routers
-├── repos/          # FastYamlRepository (YamlLoader-based FastApiService impl)
-└── __init__.py     # Version, exports (FastApiBuilder, FastAPI alias)
+├── builders/       # FastApiBuilder (extends AppBuilder, aliased as FastAPI)
+├── contexts/       # FastApiContext (extends OpenApiContext), FastRequestContext (alias)
+└── __init__.py     # Version, exports
 ```
+
+All domain-layer packages (`domain/`, `interfaces/`, `events/`, `mappers/`, `repos/`) were removed in v0.3. Consumers import directly from `tiferet_openapi`.
 
 ### Key Concepts
 
-- **FastApiBuilder** (`builders/fast.py`): Extends `tiferet.builders.AppBuilder`. Primary entry point for building FastAPI applications. Methods: `get_routers()`, `build_router()`, `build_fast_app()`, `run()`. Exported as `FastAPI` alias.
-- **FastApiContext** (`contexts/fast.py`): Extends `AppInterfaceContext`. Manages request/response lifecycle. Accepts `get_route_evt` and `get_status_code_evt` domain events. Handles error formatting via `TiferetAPIError` with HTTP status codes.
-- **FastRequestContext** (`contexts/request.py`): Extends `RequestContext`. Serializes `BaseModel` results via `model_dump()`.
-- **FastRoute / FastRouter** (`domain/fast.py`): Pydantic v2 `DomainObject` subclasses defining route and router structure.
-- **FastApiService** (`interfaces/fast.py`): `Service(ABC)` with `get_routers()`, `get_route()`, `get_status_code()`.
-- **GetRouters / GetRoute / GetStatusCode** (`events/fast.py`): `DomainEvent` subclasses injected with `FastApiService`.
-- **FastYamlRepository** (`repos/fast.py`): Implements `FastApiService` using `YamlLoader` for YAML file access and `FastRouterYamlObject` for mapping.
-- **Mappers** (`mappers/fast.py`): `FastRouteAggregate`, `FastRouterAggregate`, `FastRouteYamlObject`, `FastRouterYamlObject`.
+- **FastApiBuilder** (`builders/fast.py`): Extends `tiferet.builders.AppBuilder`. Primary entry point. Methods: `resolve_model()` (static, dynamic Pydantic model import), `get_routers()`, `build_router()` (passes Swagger metadata to FastAPI), `build_fast_app()`, `run()`.
+- **FastApiContext** (`contexts/fast.py`): Extends `OpenApiContext` (from `tiferet_openapi`). Overrides `handle_error()` to convert `TiferetAPIError` into FastAPI's `HTTPException` with proper HTTP status codes and structured error details.
+- **FastRequestContext** (`contexts/request.py`): Alias for `OpenApiRequestContext`. Serializes `BaseModel` results via `model_dump()`.
 
 ### Runtime Flow
 
 1. `FastApiBuilder()` initializes cache and service provider.
-2. `load_app_service()` loads app configuration.
-3. `load_interface(interface_id)` resolves `FastApiContext` with injected domain events.
-4. `get_routers()` resolves `get_routers_evt` from the service provider, which calls `FastYamlRepository.get_routers()`.
-5. `build_fast_app()` assembles a `FastAPI` instance with middleware and routers.
-6. At runtime, `FastApiContext.handle_error()` resolves HTTP status codes via `GetStatusCode` event, and `handle_response()` resolves route status codes via `GetRoute` event.
+2. `load_app_service(app_yaml_file='config.yml')` loads app configuration.
+3. `load_interface(interface_id)` resolves `FastApiContext` with injected domain events (`GetRouters`, `GetRoute`, `GetStatusCode` from `tiferet_openapi`).
+4. `get_routers()` resolves `get_routers_evt`, which calls `OpenApiYamlRepository.get_routers()`.
+5. `build_router()` resolves `response_model` via `resolve_model()` and passes Swagger metadata (`summary`, `description`, `tags`, `response_model`) to `add_api_route()`.
+6. `build_fast_app()` assembles a `FastAPI` instance with middleware and routers.
+7. At runtime, `FastApiContext.handle_error()` converts domain errors to `HTTPException` with status codes resolved via `GetStatusCode`, and `handle_response()` resolves route status codes via `GetRoute`.
 
 ## Configuration
 
-Applications are configured via YAML files:
+v0.3 uses the tiferet v2 beta consolidated `config.yml` strategy — a single YAML file at the project root containing all sections:
 
-- `app.yml` — Interface definitions (module_path, class_name, service dependencies)
-- `fast.yml` — FastAPI routers, routes, and error-to-status-code mappings
-- `container.yml` — Feature-level DI service configurations
-- `feature.yml` — Feature workflows (steps with service_id, parameters)
-- `error.yml` — Error definitions with multilingual messages
-- `logging.yml` — Logging formatters, handlers, loggers
+- `interfaces` — App interface definitions (module_path, class_name, service dependencies)
+- `openapi` — Routers, routes (with Swagger metadata: `summary`, `description`, `tags`, `request_model`, `response_model`), and error-to-status-code mappings
+- `services` — Feature-level DI service configurations
+- `features` — Feature workflows (steps with `service_id`, `params`)
+- `errors` — Error definitions with multilingual messages
+
+The `openapi_yaml_file` parameter in the interface config can point to the same `config.yml`.
 
 ## Testing
 
@@ -63,15 +57,15 @@ Applications are configured via YAML files:
 - **Test location:** Co-located in `<package>/tests/` directories.
 - **Run tests:** `pytest tiferet_fast/` from project root (with venv activated).
 - **Test patterns:**
-  - Domain event tests use `DomainEvent.handle()` with mocked `FastApiService`.
-  - Repository tests use `tmp_path` fixtures with real temporary YAML files.
-  - Context tests mock domain events and verify `TiferetAPIError` flow.
+  - Builder tests verify `resolve_model()` and Swagger-enriched `build_router()`.
+  - Context tests mock domain events and verify `HTTPException` flow.
+  - Request context tests verify `BaseModel` serialization.
 
 ## Structured Code Style
 
 Follows the Tiferet structured code style. See the [Tiferet AGENTS.md](https://github.com/greatstrength/tiferet) for full conventions:
 
-- `# *** <section>` — Top-level (imports, exports, builders, contexts, events, etc.)
+- `# *** <section>` — Top-level (imports, exports, builders, contexts)
 - `# ** <category>: <name>` — Mid-level (individual components)
 - `# * <component>` — Low-level (attribute, init, method)
 - RST docstrings with `:param`, `:type`, `:return`, `:rtype`.
@@ -81,16 +75,7 @@ Follows the Tiferet structured code style. See the [Tiferet AGENTS.md](https://g
 
 `tiferet_fast/__init__.py` exports:
 
+- `FastApiContext` — The FastAPI-specific API context.
+- `FastRequestContext` — Alias for `OpenApiRequestContext`.
 - `FastApiBuilder` — The primary application builder.
 - `FastAPI` — Alias for `FastApiBuilder`.
-
-## Migration from v0.1.x
-
-| v0.1.x Package | v0.2.0 Package | Key Change |
-|---|---|---|
-| `models/` | `domain/` | Pydantic v2 `DomainObject` replaces schematics `ModelObject` |
-| `contracts/` | `interfaces/` | `Service(ABC)` replaces typed contracts |
-| `data/` | `mappers/` | `Aggregate` + `TransferObject` replace `DataObject` |
-| `handlers/` | `events/` | `DomainEvent` subclasses replace handler classes |
-| `proxies/` | `repos/` | `YamlLoader` composition replaces inheritance |
-| N/A | `builders/` | New `FastApiBuilder(AppBuilder)` entry point |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Tiferet Fast elevates the Tiferet Python framework by enabling developers to build high-performance, asynchronous APIs using FastAPI, grounded in Domain-Driven Design (DDD) principles. Inspired by the concept of beauty in harmony, this extension integrates Tiferet's domain-event-driven architecture with FastAPI's modern, declarative routing and automatic OpenAPI documentation. The result is a robust, modular platform for crafting scalable web services that transform complex business logic into elegant, extensible API designs.
+Tiferet Fast elevates the Tiferet Python framework by enabling developers to build high-performance, asynchronous APIs using FastAPI, grounded in Domain-Driven Design (DDD) principles. Starting with v0.3, Tiferet Fast uses [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) as the shared domain backbone for route configuration, Swagger metadata, and error-to-status-code mappings — leaving only FastAPI-specific concerns (builder assembly and context error handling) in this package.
 
 For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet documentation](https://github.com/greatstrength/tiferet).
 
@@ -12,6 +12,7 @@ For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet doc
 
 - Python 3.10 or later
 - [Tiferet](https://github.com/greatstrength/tiferet) >= 2.0.0b1
+- [Tiferet OpenAPI](https://github.com/greatstrength/tiferet-openapi) >= 0.1.2
 
 ### Installation
 
@@ -19,101 +20,70 @@ For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet doc
 pip install tiferet-fast
 ```
 
-### Project Structure
+## Architecture (v0.3.0)
 
-```plaintext
-project_root/
-├── calc_fast_api.py
-├── app/
-│   ├── events/
-│   │   ├── __init__.py
-│   │   ├── calc.py
-│   │   └── settings.py
-│   └── configs/
-│       ├── __init__.py
-│       ├── app.yml
-│       ├── container.yml
-│       ├── error.yml
-│       ├── feature.yml
-│       ├── fast.yml
-│       └── logging.yml
-```
+Tiferet Fast v0.3 is a thin adapter layer. Domain objects, service interfaces, domain events, mappers, and repositories all live in `tiferet-openapi`. This package provides only:
 
-The `app/events/` directory holds domain event classes for arithmetic operations. The `app/configs/` directory contains YAML configuration files for application interfaces, dependency injection, error handling, feature workflows, FastAPI routing, and logging. The `calc_fast_api.py` script initializes and serves the FastAPI application using `FastApiBuilder`.
+- **Builders** (`tiferet_fast.builders`) — `FastApiBuilder` extends `AppBuilder` to assemble FastAPI applications from `ApiRouter`/`ApiRoute` domain objects, with Swagger model resolution via `resolve_model()`.
+- **Contexts** (`tiferet_fast.contexts`) — `FastApiContext` extends `OpenApiContext` with FastAPI-specific error handling (converts `TiferetAPIError` to `HTTPException`). `FastRequestContext` is an alias for `OpenApiRequestContext`.
 
-## Architecture (v0.2.0)
-
-Tiferet Fast v0.2.0 aligns with the Tiferet v2.0 layered architecture:
-
-- **Domain** (`tiferet_fast.domain`) — `FastRoute`, `FastRouter` domain objects (Pydantic v2).
-- **Interfaces** (`tiferet_fast.interfaces`) — `FastApiService` abstract service contract.
-- **Mappers** (`tiferet_fast.mappers`) — Aggregates and YAML TransferObjects for routes/routers.
-- **Events** (`tiferet_fast.events`) — `GetRouters`, `GetRoute`, `GetStatusCode` domain events.
-- **Repos** (`tiferet_fast.repos`) — `FastYamlRepository` (YamlLoader-based service implementation).
-- **Contexts** (`tiferet_fast.contexts`) — `FastApiContext`, `FastRequestContext`.
-- **Builders** (`tiferet_fast.builders`) — `FastApiBuilder` (primary entry point, aliased as `FastAPI`).
+All domain-layer concerns (routes, routers, request/response models, events, repos) are imported directly from `tiferet_openapi`.
 
 ## Usage
 
-### Configuring Routes in `fast.yml`
+### Configuration
+
+Tiferet v2 beta supports a consolidated `config.yml` at the project root:
 
 ```yaml
-fast:
+interfaces:
+  calc_fast_api:
+    name: Calculator FastAPI
+    description: Arithmetic operations via FastAPI with Swagger docs
+    module_path: tiferet_fast.contexts.fast
+    class_name: FastApiContext
+    attrs:
+      get_routers_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetRouters
+      get_route_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetRoute
+      get_status_code_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetStatusCode
+      openapi_service:
+        module_path: tiferet_openapi.repos.openapi
+        class_name: OpenApiYamlRepository
+        params:
+          openapi_yaml_file: config.yml
+
+openapi:
   routers:
     calc:
       prefix: /calc
       routes:
         add:
           path: /add
-          methods: [POST, GET]
+          methods: [POST]
           status_code: 200
-        subtract:
-          path: /subtract
-          methods: [POST, GET]
-          status_code: 200
+          summary: Add two numbers
+          description: Adds two numbers and returns the result.
+          request_model: app.domain.request.TwoOperandRequest
+          response_model: app.domain.request.CalculatorResponse
   errors:
-    INVALID_INPUT: 400
-    DIVISION_BY_ZERO: 422
+    DIVISION_BY_ZERO: 400
+    INVALID_INPUT: 422
 ```
 
-### Configuring the App Interface in `app.yml`
-
-```yaml
-interfaces:
-  calc_fast_api:
-    name: Basic Calculator API
-    description: Perform basic calculator operations via FastAPI
-    module_path: tiferet_fast.contexts.fast
-    class_name: FastApiContext
-    attrs:
-      get_route_evt:
-        module_path: tiferet_fast.events.fast
-        class_name: GetRoute
-      get_status_code_evt:
-        module_path: tiferet_fast.events.fast
-        class_name: GetStatusCode
-      fast_api_service:
-        module_path: tiferet_fast.repos.fast
-        class_name: FastYamlRepository
-        params:
-          fast_yaml_file: app/configs/fast.yml
-```
+Routes support Swagger metadata fields (`summary`, `description`, `tags`, `request_model`, `response_model`). The `response_model` is dynamically resolved by `FastApiBuilder.resolve_model()` and passed to FastAPI's `add_api_route()` for native Swagger schema generation.
 
 ### Building and Running the API
 
 ```python
-from tiferet_fast import FastAPI
-from starlette.requests import Request
-from starlette.responses import JSONResponse
+from fastapi import Request
+from tiferet_fast import FastApiBuilder
 
-# Create the builder and load the app service.
-app = FastAPI()
-app.load_app_service()
-
-# Load the interface context.
-context = app.load_interface('calc_fast_api')
-
-# Define a view function for handling requests.
 async def view_func(request: Request):
     data = await request.json() if request.headers.get('content-type') == 'application/json' else {}
     data.update(dict(request.query_params))
@@ -124,40 +94,43 @@ async def view_func(request: Request):
         headers=headers,
         data=data,
     )
-    return JSONResponse(response, status_code=status_code)
+    return {'result': response}
+
+# Create the builder and load configuration.
+builder = FastApiBuilder()
+builder.load_app_service(app_yaml_file='config.yml')
 
 # Build the FastAPI application.
-fast_app = app.build_fast_app('calc_fast_api', view_func=view_func)
+fast_app = builder.run('calc_fast_api', view_func)
 
-# Serve with uvicorn.
-if __name__ == '__main__':
-    import uvicorn
-    uvicorn.run(fast_app, host='127.0.0.1', port=8000)
+# Access the context for the view function closure.
+context = builder.load_interface('calc_fast_api')
 ```
 
-### Testing the API
+Serve with uvicorn:
 
 ```bash
-# Add two numbers
-curl -X POST http://127.0.0.1:8000/calc/add -H "Content-Type: application/json" -d '{"a": 1, "b": 2}'
-# Output: 3
-
-# Calculate square root
-curl -X POST http://127.0.0.1:8000/calc/sqrt -H "Content-Type: application/json" -d '{"a": 16}'
-# Output: 4.0
+uvicorn calc_fast_api:fast_app --reload
 ```
 
-## Migration from v0.1.x
+Swagger UI is available at `http://127.0.0.1:8000/docs`.
 
-v0.2.0 is a breaking release that aligns with Tiferet v2.0:
+### Example
 
-- **`models/`** → `domain/` (Pydantic v2 `DomainObject` replaces schematics `ModelObject`)
-- **`contracts/`** → `interfaces/` (`Service(ABC)` replaces typed contracts)
-- **`data/`** → `mappers/` (`Aggregate` + `TransferObject` replace `DataObject`)
-- **`handlers/`** → `events/` (`DomainEvent` subclasses replace handler classes)
-- **`proxies/`** → `repos/` (`YamlLoader` composition replaces `YamlConfigurationProxy` inheritance)
-- **`FastApiContext.build_fast_app()`** → `FastApiBuilder.build_fast_app()` (builder pattern)
-- **Top-level export**: `from tiferet_fast import FastAPI` (alias for `FastApiBuilder`)
+See the [`example/`](example/) directory for a complete calculator application demonstrating all v0.3 features.
+
+## Migration from v0.2.x
+
+v0.3.0 removes all domain/interface/event/mapper/repo layers from this package in favor of `tiferet-openapi`:
+
+- **`tiferet_fast.domain`** — Removed. Use `tiferet_openapi.domain` (`ApiRoute`, `ApiRouter`, `ApiRequestModel`, `ApiResponseModel`).
+- **`tiferet_fast.interfaces`** — Removed. Use `tiferet_openapi.interfaces` (`OpenApiService`).
+- **`tiferet_fast.events`** — Removed. Use `tiferet_openapi.events` (`GetRouters`, `GetRoute`, `GetStatusCode`).
+- **`tiferet_fast.mappers`** — Removed. Use `tiferet_openapi.mappers`.
+- **`tiferet_fast.repos`** — Removed. Use `tiferet_openapi.repos` (`OpenApiYamlRepository`).
+- **`fast.yml`** config with `fast:` root key — Replaced by `openapi.yml` or consolidated `config.yml` with `openapi:` root key.
+- **`FastApiContext`** — Now extends `OpenApiContext` (from `tiferet_openapi`) with `handle_error()` converting `TiferetAPIError` to `HTTPException`.
+- **`FastRequestContext`** — Now an alias for `OpenApiRequestContext`.
 
 ## License
 

--- a/tiferet_fast/__init__.py
+++ b/tiferet_fast/__init__.py
@@ -6,10 +6,14 @@
 # Export the main application builder and related modules.
 # Use a try-except block to avoid import errors on build systems.
 try:
+    from .contexts import FastApiContext, FastRequestContext
     from .builders import FastApiBuilder, FastApiBuilder as FastAPI
-except Exception:
+except Exception as e:
+    import os, sys
+    if not os.getenv('TIFERET_SILENT_IMPORTS'):
+        print(f"Warning: Failed to import Tiferet Fast modules: {e}", file=sys.stderr)
     pass
 
 # *** version
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary

Final cleanup for the v0.3.0 milestone: version bump, updated exports, and rewritten documentation.

Closes #37

## Changes

- **Version bump** — `__version__` set to `"0.3.0"`.
- **Updated exports** — `FastApiContext` and `FastRequestContext` now exported from top-level `__init__.py` alongside `FastApiBuilder`/`FastAPI`. Includes `TIFERET_SILENT_IMPORTS` env var support.
- **README rewrite** — Reflects v0.3 architecture: tiferet-openapi as domain backbone, consolidated `config.yml`, Swagger model resolution via `resolve_model()`, `HTTPException` error handling, migration guide from v0.2.x, and reference to `example/`.
- **AGENTS.md rewrite** — Documents v0.3 package layout (only `builders/` and `contexts/`), runtime flow with Swagger metadata, consolidated config strategy, and updated testing patterns.
- **`pyproject.toml`** — Verified correct (already lists only the two sub-packages and correct dependencies).

## Test Results

20/20 tests passing. All exports verified.

---

[Warp conversation](https://app.warp.dev/conversation/df250180-4812-450f-8d17-ae82f901e073)

Co-Authored-By: Oz <oz-agent@warp.dev>