### PR TITLE
Packaging – Dependencies, Version Bump, and Documentation (#46)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Tiferet Fast (v0.3.0)
+# AGENTS.md — Tiferet Fast (v0.4.0)
 
 ## Project Overview
 
-**Tiferet Fast** is a thin FastAPI adapter for the Tiferet Python framework. Starting with v0.3, all domain objects, service interfaces, domain events, mappers, and repositories live in [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi). This package provides only FastAPI-specific builder assembly and context error handling.
+**Tiferet Fast** is a thin FastAPI adapter for the Tiferet Python framework. Starting with v0.3, all domain objects, service interfaces, domain events, mappers, and repositories live in [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi). In v0.4, the class-based `FastApiBuilder` is replaced by composable **blueprint functions**, aligning with the Tiferet core blueprint pattern.
 
 - **Repository:** https://github.com/greatstrength/tiferet-fast
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.3.0`
-- **Dependencies:** `tiferet>=2.0.0b1`, `tiferet-openapi>=0.1.2`, `fastapi>=0.118.0`, `starlette-context>=0.4.0`
+- **Version:** `0.4.0`
+- **Dependencies:** `tiferet-openapi>=0.1.3`, `fastapi>=0.118.0`, `starlette-context>=0.4.0`
 
 ## Architecture
 
@@ -16,32 +16,38 @@
 
 ```
 tiferet_fast/
-├── builders/       # FastApiBuilder (extends AppBuilder, aliased as FastAPI)
+├── blueprints/     # Blueprint functions (build_fast_app, build_router, get_routers, resolve_model)
 ├── contexts/       # FastApiContext (extends OpenApiContext), FastRequestContext (alias)
 └── __init__.py     # Version, exports
 ```
 
-All domain-layer packages (`domain/`, `interfaces/`, `events/`, `mappers/`, `repos/`) were removed in v0.3. Consumers import directly from `tiferet_openapi`.
+All domain-layer packages (`domain/`, `interfaces/`, `events/`, `mappers/`, `repos/`) were removed in v0.3. The `builders/` package was removed in v0.4 in favor of `blueprints/`. Consumers import domain types directly from `tiferet_openapi`.
 
 ### Key Concepts
 
-- **FastApiBuilder** (`builders/fast.py`): Extends `tiferet.builders.AppBuilder`. Primary entry point. Methods: `resolve_model()` (static, dynamic Pydantic model import), `get_routers()`, `build_router()` (passes Swagger metadata to FastAPI), `build_fast_app()`, `run()`.
+- **Blueprint Functions** (`blueprints/fast.py`): Composable functions that replace the `FastApiBuilder` class.
+  - `build_fast_app(interface_id, view_func, **parameters)` — One-call assembly of a complete FastAPI app with middleware and routers. Uses `resolve_interface()` and `realize_interface()` from `tiferet.blueprints.main`.
+  - `build_router(router, view_func)` — Builds a single `APIRouter` from an `ApiRouter` domain object, passing Swagger metadata (`summary`, `description`, `tags`, `response_model`) to `add_api_route()`.
+  - `get_routers(service_provider)` — Resolves the `get_routers_evt` from the service provider and executes it.
+  - `resolve_model(model_path)` — Dynamically imports a Pydantic model class by dotted path for Swagger schema generation.
+  - `FastAPI` — Alias for `build_fast_app`.
 - **FastApiContext** (`contexts/fast.py`): Extends `OpenApiContext` (from `tiferet_openapi`). Overrides `handle_error()` to convert `TiferetAPIError` into FastAPI's `HTTPException` with proper HTTP status codes and structured error details.
 - **FastRequestContext** (`contexts/request.py`): Alias for `OpenApiRequestContext`. Serializes `BaseModel` results via `model_dump()`.
 
 ### Runtime Flow
 
-1. `FastApiBuilder()` initializes cache and service provider.
-2. `load_app_service(app_yaml_file='config.yml')` loads app configuration.
-3. `load_interface(interface_id)` resolves `FastApiContext` with injected domain events (`GetRouters`, `GetRoute`, `GetStatusCode` from `tiferet_openapi`).
-4. `get_routers()` resolves `get_routers_evt`, which calls `OpenApiYamlRepository.get_routers()`.
-5. `build_router()` resolves `response_model` via `resolve_model()` and passes Swagger metadata (`summary`, `description`, `tags`, `response_model`) to `add_api_route()`.
-6. `build_fast_app()` assembles a `FastAPI` instance with middleware and routers.
-7. At runtime, `FastApiContext.handle_error()` converts domain errors to `HTTPException` with status codes resolved via `GetStatusCode`, and `handle_response()` resolves route status codes via `GetRoute`.
+1. `build_fast_app(interface_id, view_func, **parameters)` is called with the interface ID, view function, and config parameters.
+2. `resolve_interface()` (from `tiferet.blueprints.main`) loads the interface definition and default services from YAML config.
+3. `realize_interface()` instantiates the `FastApiContext` with injected domain events (`GetRouters`, `GetRoute`, `GetStatusCode` from `tiferet_openapi`).
+4. A `ServiceProvider` is created and seeded with default service dependencies.
+5. `get_routers()` resolves `get_routers_evt`, which calls `OpenApiYamlRepository.get_routers()`.
+6. `build_router()` resolves `response_model` via `resolve_model()` and passes Swagger metadata to `add_api_route()`.
+7. A `FastAPI` instance is assembled with middleware and routers, then returned.
+8. At runtime, `FastApiContext.handle_error()` converts domain errors to `HTTPException` with status codes resolved via `GetStatusCode`, and `handle_response()` resolves route status codes via `GetRoute`.
 
 ## Configuration
 
-v0.3 uses the tiferet v2 beta consolidated `config.yml` strategy — a single YAML file at the project root containing all sections:
+v0.4 uses the tiferet v2 beta consolidated `config.yml` strategy — a single YAML file at the project root containing all sections:
 
 - `interfaces` — App interface definitions (module_path, class_name, service dependencies)
 - `openapi` — Routers, routes (with Swagger metadata: `summary`, `description`, `tags`, `request_model`, `response_model`), and error-to-status-code mappings
@@ -57,7 +63,7 @@ The `openapi_yaml_file` parameter in the interface config can point to the same 
 - **Test location:** Co-located in `<package>/tests/` directories.
 - **Run tests:** `pytest tiferet_fast/` from project root (with venv activated).
 - **Test patterns:**
-  - Builder tests verify `resolve_model()` and Swagger-enriched `build_router()`.
+  - Blueprint tests verify `resolve_model()` and Swagger-enriched `build_router()`.
   - Context tests mock domain events and verify `HTTPException` flow.
   - Request context tests verify `BaseModel` serialization.
 
@@ -65,7 +71,7 @@ The `openapi_yaml_file` parameter in the interface config can point to the same 
 
 Follows the Tiferet structured code style. See the [Tiferet AGENTS.md](https://github.com/greatstrength/tiferet) for full conventions:
 
-- `# *** <section>` — Top-level (imports, exports, builders, contexts)
+- `# *** <section>` — Top-level (imports, exports, blueprints, contexts)
 - `# ** <category>: <name>` — Mid-level (individual components)
 - `# * <component>` — Low-level (attribute, init, method)
 - RST docstrings with `:param`, `:type`, `:return`, `:rtype`.
@@ -77,5 +83,5 @@ Follows the Tiferet structured code style. See the [Tiferet AGENTS.md](https://g
 
 - `FastApiContext` — The FastAPI-specific API context.
 - `FastRequestContext` — Alias for `OpenApiRequestContext`.
-- `FastApiBuilder` — The primary application builder.
-- `FastAPI` — Alias for `FastApiBuilder`.
+- `build_fast_app` — The primary blueprint function for assembling a FastAPI app.
+- `FastAPI` — Alias for `build_fast_app`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-Tiferet Fast elevates the Tiferet Python framework by enabling developers to build high-performance, asynchronous APIs using FastAPI, grounded in Domain-Driven Design (DDD) principles. Starting with v0.3, Tiferet Fast uses [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) as the shared domain backbone for route configuration, Swagger metadata, and error-to-status-code mappings — leaving only FastAPI-specific concerns (builder assembly and context error handling) in this package.
+Tiferet Fast elevates the Tiferet Python framework by enabling developers to build high-performance, asynchronous APIs using FastAPI, grounded in Domain-Driven Design (DDD) principles. Starting with v0.3, Tiferet Fast uses [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) as the shared domain backbone for route configuration, Swagger metadata, and error-to-status-code mappings — leaving only FastAPI-specific concerns in this package.
+
+In v0.4, the class-based `FastApiBuilder` is replaced by a set of composable **blueprint functions** (`build_fast_app`, `build_router`, `get_routers`, `resolve_model`), aligning with the Tiferet core blueprint pattern for a simpler, more functional API.
 
 For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet documentation](https://github.com/greatstrength/tiferet).
 
@@ -11,8 +13,7 @@ For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet doc
 ### Requirements
 
 - Python 3.10 or later
-- [Tiferet](https://github.com/greatstrength/tiferet) >= 2.0.0b1
-- [Tiferet OpenAPI](https://github.com/greatstrength/tiferet-openapi) >= 0.1.2
+- [Tiferet OpenAPI](https://github.com/greatstrength/tiferet-openapi) >= 0.1.3 (pulls in [Tiferet](https://github.com/greatstrength/tiferet) transitively)
 
 ### Installation
 
@@ -20,11 +21,16 @@ For a deeper understanding of Tiferet's core concepts, refer to the [Tiferet doc
 pip install tiferet-fast
 ```
 
-## Architecture (v0.3.0)
+## Architecture (v0.4.0)
 
-Tiferet Fast v0.3 is a thin adapter layer. Domain objects, service interfaces, domain events, mappers, and repositories all live in `tiferet-openapi`. This package provides only:
+Tiferet Fast v0.4 is a thin adapter layer. Domain objects, service interfaces, domain events, mappers, and repositories all live in `tiferet-openapi`. This package provides only:
 
-- **Builders** (`tiferet_fast.builders`) — `FastApiBuilder` extends `AppBuilder` to assemble FastAPI applications from `ApiRouter`/`ApiRoute` domain objects, with Swagger model resolution via `resolve_model()`.
+- **Blueprints** (`tiferet_fast.blueprints`) — Composable functions for assembling FastAPI applications from `ApiRouter`/`ApiRoute` domain objects:
+  - `build_fast_app(interface_id, view_func, **parameters)` — One-call assembly of a complete FastAPI app with middleware and routers.
+  - `build_router(router, view_func)` — Builds a single `APIRouter` from an `ApiRouter` domain object with Swagger metadata.
+  - `get_routers(service_provider)` — Resolves routers via the service provider.
+  - `resolve_model(model_path)` — Dynamically imports a Pydantic model class by dotted path.
+  - `FastAPI` — Alias for `build_fast_app`.
 - **Contexts** (`tiferet_fast.contexts`) — `FastApiContext` extends `OpenApiContext` with FastAPI-specific error handling (converts `TiferetAPIError` to `HTTPException`). `FastRequestContext` is an alias for `OpenApiRequestContext`.
 
 All domain-layer concerns (routes, routers, request/response models, events, repos) are imported directly from `tiferet_openapi`.
@@ -76,14 +82,16 @@ openapi:
     INVALID_INPUT: 422
 ```
 
-Routes support Swagger metadata fields (`summary`, `description`, `tags`, `request_model`, `response_model`). The `response_model` is dynamically resolved by `FastApiBuilder.resolve_model()` and passed to FastAPI's `add_api_route()` for native Swagger schema generation.
+Routes support Swagger metadata fields (`summary`, `description`, `tags`, `request_model`, `response_model`). The `response_model` is dynamically resolved by `resolve_model()` and passed to FastAPI's `add_api_route()` for native Swagger schema generation.
 
 ### Building and Running the API
 
 ```python
 from fastapi import Request
-from tiferet_fast import FastApiBuilder
+from tiferet_fast import FastAPI, FastApiContext
+from tiferet_openapi.blueprints.main import realize_interface, resolve_interface
 
+# Define the view function.
 async def view_func(request: Request):
     data = await request.json() if request.headers.get('content-type') == 'application/json' else {}
     data.update(dict(request.query_params))
@@ -96,15 +104,12 @@ async def view_func(request: Request):
     )
     return {'result': response}
 
-# Create the builder and load configuration.
-builder = FastApiBuilder()
-builder.load_app_service(app_yaml_file='config.yml')
+# Build the FastAPI application in one call.
+fast_app = FastAPI('calc_fast_api', view_func, app_yaml_file='config.yml')
 
-# Build the FastAPI application.
-fast_app = builder.run('calc_fast_api', view_func)
-
-# Access the context for the view function closure.
-context = builder.load_interface('calc_fast_api')
+# Realize the context for the view function closure.
+app_interface, _ = resolve_interface('calc_fast_api', app_yaml_file='config.yml')
+context = realize_interface(app_interface, 'calc_fast_api')
 ```
 
 Serve with uvicorn:
@@ -117,11 +122,40 @@ Swagger UI is available at `http://127.0.0.1:8000/docs`.
 
 ### Example
 
-See the [`example/`](example/) directory for a complete calculator application demonstrating all v0.3 features.
+See the [`example/`](example/) directory for a complete calculator application demonstrating all features.
+
+## Migration from v0.3.x
+
+v0.4.0 replaces the class-based `FastApiBuilder` with composable blueprint functions:
+
+- **`FastApiBuilder` class** — Removed. Use `build_fast_app()` (or its alias `FastAPI`) from `tiferet_fast.blueprints`.
+- **`FastApiBuilder().load_app_service()`** — No longer needed. Pass `app_yaml_file` as a keyword argument to `build_fast_app()`.
+- **`FastApiBuilder().run(interface_id, view_func)`** — Replace with `build_fast_app(interface_id, view_func, app_yaml_file='config.yml')`.
+- **`FastApiBuilder().load_interface(interface_id)`** — Use `resolve_interface()` and `realize_interface()` from `tiferet_openapi.blueprints.main`.
+- **Direct `tiferet` dependency** — Removed from `pyproject.toml`. Tiferet is now pulled in transitively via `tiferet-openapi>=0.1.3`.
+
+### Before (v0.3.x)
+
+```python
+from tiferet_fast import FastApiBuilder
+
+builder = FastApiBuilder()
+builder.load_app_service(app_yaml_file='config.yml')
+fast_app = builder.run('calc_fast_api', view_func)
+context = builder.load_interface('calc_fast_api')
+```
+
+### After (v0.4.0)
+
+```python
+from tiferet_fast import FastAPI
+
+fast_app = FastAPI('calc_fast_api', view_func, app_yaml_file='config.yml')
+```
 
 ## Migration from v0.2.x
 
-v0.3.0 removes all domain/interface/event/mapper/repo layers from this package in favor of `tiferet-openapi`:
+v0.3.0 removed all domain/interface/event/mapper/repo layers from this package in favor of `tiferet-openapi`:
 
 - **`tiferet_fast.domain`** — Removed. Use `tiferet_openapi.domain` (`ApiRoute`, `ApiRouter`, `ApiRequestModel`, `ApiResponseModel`).
 - **`tiferet_fast.interfaces`** — Removed. Use `tiferet_openapi.interfaces` (`OpenApiService`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet>=2.0.0b1",
-    "tiferet-openapi>=0.1.2",
+    "tiferet-openapi>=0.1.3",
     "fastapi>=0.118.0",
     "starlette-context>=0.4.0"
 ]
@@ -34,7 +33,7 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 include = [
     "tiferet_fast",
-    "tiferet_fast.builders",
+    "tiferet_fast.blueprints",
     "tiferet_fast.contexts"
 ]
 


### PR DESCRIPTION
## Summary

Updates package dependencies, documentation, and metadata to reflect the v0.4.0 blueprint architecture introduced in #45.

## Changes

- **`pyproject.toml`**: Removed direct `tiferet>=2.0.0b1` dependency (now transitive via `tiferet-openapi>=0.1.3`). Updated `packages.find` to include `tiferet_fast.blueprints` and remove `tiferet_fast.builders`.
- **`README.md`**: Updated architecture section for v0.4.0 blueprints, replaced builder usage examples with `build_fast_app`/`FastAPI` function calls, added "Migration from v0.3.x" section with before/after examples.
- **`AGENTS.md`**: Updated version to 0.4.0, dependencies, package layout, key concepts (blueprint functions), runtime flow, and package exports.

## Verification

- `pip install .` succeeds with `tiferet` pulled in transitively.
- `tiferet_fast.__version__` returns `'0.4.0'`.

Closes #46

---
[Warp conversation](https://app.warp.dev/conversation/2049c639-57c1-45e0-805c-1a73c28bb640)

Co-Authored-By: Oz <oz-agent@warp.dev>