### PR TITLE
Blueprints – Fix DI eager wiring and update to tiferet-openapi 1.0.0b1

### DIFF
--- a/example/calc_fast_api.py
+++ b/example/calc_fast_api.py
@@ -4,7 +4,12 @@
 
 # ** infra
 from fastapi import Request
-from tiferet_fast import FastApiBuilder
+from tiferet_fast import build_fast_app
+from tiferet.blueprints.main import (
+    resolve_interface,
+    realize_interface,
+    create_service_provider,
+)
 
 
 # *** functions
@@ -46,12 +51,19 @@ async def view_func(request: Request):
 
 # *** exec
 
-# Create the builder and load the app service from config.yml.
-builder = FastApiBuilder()
-builder.load_app_service(app_yaml_file='config.yml')
+# Resolve the interface definition and extract constants for pre-seeding.
+# NOTE: Workaround for DynamicServiceProvider eager wiring — constants must
+# be registered before the types that depend on them.
+app_interface, default_services = resolve_interface('calc_fast_api', app_yaml_file='config.yml')
+type_map = app_interface.get_service_type_mapping()
+constants = {k: v for k, v in type_map.items() if not isinstance(v, type)}
 
-# Build the FastAPI app with routers.
-fast_app = builder.run('calc_fast_api', view_func)
+# Load the app interface context with a pre-seeded service provider.
+context = realize_interface(
+    app_interface,
+    'calc_fast_api',
+    service_provider=create_service_provider(**constants),
+)
 
-# Access the context for the view function closure.
-context = builder.load_interface('calc_fast_api')
+# Build the FastAPI app with middleware and routers.
+fast_app = build_fast_app('calc_fast_api', view_func, app_yaml_file='config.yml')

--- a/example/config.yml
+++ b/example/config.yml
@@ -5,6 +5,11 @@ interfaces:
     module_path: tiferet_fast.contexts.fast
     class_name: FastApiContext
     attrs:
+      openapi_service:
+        module_path: tiferet_openapi.repos.openapi
+        class_name: OpenApiYamlRepository
+        params:
+          openapi_yaml_file: config.yml
       get_routers_evt:
         module_path: tiferet_openapi.events.openapi
         class_name: GetRouters
@@ -14,11 +19,6 @@ interfaces:
       get_status_code_evt:
         module_path: tiferet_openapi.events.openapi
         class_name: GetStatusCode
-      openapi_service:
-        module_path: tiferet_openapi.repos.openapi
-        class_name: OpenApiYamlRepository
-        params:
-          openapi_yaml_file: config.yml
 
 openapi:
   routers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet-openapi>=0.1.3",
+    "tiferet-openapi>=1.0.0b1",
     "fastapi>=0.118.0",
     "starlette-context>=0.4.0"
 ]

--- a/tiferet_fast/__init__.py
+++ b/tiferet_fast/__init__.py
@@ -16,4 +16,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = "1.0.0b1"
+__version__ = "1.0.0b2"

--- a/tiferet_fast/blueprints/fast.py
+++ b/tiferet_fast/blueprints/fast.py
@@ -129,8 +129,22 @@ def build_fast_app(interface_id: str, view_func: Callable, **parameters) -> Fast
     # Resolve the interface definition.
     app_interface, default_services = resolve_interface(interface_id, **parameters)
 
-    # Realize the app interface context.
-    interface_context = realize_interface(app_interface, interface_id)
+    # Build a unified type map from both the interface and default services.
+    type_map = app_interface.get_service_type_mapping()
+    for dep in default_services:
+        type_map[dep.service_id] = dep.get_service_type()
+        type_map.update(dep.parameters)
+    type_map.update(app_interface.constants or {})
+    type_map.update(parameters)
+
+    # Separate constants and types, then create a pre-seeded provider.
+    # NOTE: Workaround for DynamicServiceProvider eager wiring — constants must
+    # be registered before the types that depend on them.
+    constants = {k: v for k, v in type_map.items() if not isinstance(v, type)}
+    service_provider = create_service_provider(**constants)
+
+    # Realize the app interface context with the pre-seeded provider.
+    interface_context = realize_interface(app_interface, interface_id, service_provider)
 
     # Create middleware.
     middleware = [
@@ -149,16 +163,7 @@ def build_fast_app(interface_id: str, view_func: Callable, **parameters) -> Fast
         middleware=middleware,
     )
 
-    # Build a service provider seeded with default service dependencies
-    # so get_routers can resolve the routers event.
-    service_provider = create_service_provider(
-        type_map={dep.service_id: dep.get_service_type() for dep in default_services},
-        **{k: v for dep in default_services for k, v in dep.parameters.items()},
-        **(app_interface.constants or {}),
-        **parameters,
-    )
-
-    # Load and include routers.
+    # Load and include routers using the same service provider.
     routers = get_routers(service_provider)
     for router in routers:
         api_router = build_router(router, view_func=view_func)


### PR DESCRIPTION
## Summary

- Fix `build_fast_app` to pre-seed constants into the service provider before type registration, working around `DynamicServiceProvider` eager wiring issue in tiferet core.
- Update `pyproject.toml` dependency to `tiferet-openapi>=1.0.0b1`.
- Update calculator example to use blueprint functions (replacing removed `FastApiBuilder`).
- Reorder interface attrs in example `config.yml` so `openapi_service` precedes its consumers.
- Bump version to `1.0.0b2`.

## Test Results

All 21 tests pass. Calculator example verified to load with correct routes and context.

---

[Conversation](https://app.warp.dev/conversation/2536980e-1576-4a52-a9e3-865a7ab888ce)

Co-Authored-By: Oz <oz-agent@warp.dev>